### PR TITLE
[UI] 검색 화면 

### DIFF
--- a/DMU-iOS/DMU-iOS.xcodeproj/project.pbxproj
+++ b/DMU-iOS/DMU-iOS.xcodeproj/project.pbxproj
@@ -62,6 +62,7 @@
 		F9D426242B3F076A008EBCC7 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9D426232B3F076A008EBCC7 /* HomeView.swift */; };
 		F9DBEA872B464C49004B64D6 /* Menu.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9DBEA862B464C49004B64D6 /* Menu.swift */; };
 		F9DBEA8A2B464EC5004B64D6 /* MealViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9DBEA892B464EC5004B64D6 /* MealViewModel.swift */; };
+		F9E4E3762B75F58600E276CC /* CustomTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9E4E3752B75F58600E276CC /* CustomTextField.swift */; };
 		F9EE42412B3C24E300307BA7 /* CustomButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9EE42402B3C24E300307BA7 /* CustomButton.swift */; };
 		F9EE42452B3C276D00307BA7 /* Onboarding-Step-One.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9EE42442B3C276D00307BA7 /* Onboarding-Step-One.swift */; };
 		F9EE42482B3C302600307BA7 /* Department.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9EE42472B3C302600307BA7 /* Department.swift */; };
@@ -121,6 +122,7 @@
 		F9D426232B3F076A008EBCC7 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 		F9DBEA862B464C49004B64D6 /* Menu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Menu.swift; sourceTree = "<group>"; };
 		F9DBEA892B464EC5004B64D6 /* MealViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MealViewModel.swift; sourceTree = "<group>"; };
+		F9E4E3752B75F58600E276CC /* CustomTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomTextField.swift; sourceTree = "<group>"; };
 		F9EE42402B3C24E300307BA7 /* CustomButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomButton.swift; sourceTree = "<group>"; };
 		F9EE42442B3C276D00307BA7 /* Onboarding-Step-One.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Onboarding-Step-One.swift"; sourceTree = "<group>"; };
 		F9EE42472B3C302600307BA7 /* Department.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Department.swift; sourceTree = "<group>"; };
@@ -399,6 +401,7 @@
 			children = (
 				F9EE42402B3C24E300307BA7 /* CustomButton.swift */,
 				F90D264A2B3DA00600C864C4 /* CustomKeyword.swift */,
+				F9E4E3752B75F58600E276CC /* CustomTextField.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -684,6 +687,7 @@
 				F9BCAA892B73D38100E717BF /* NoticeWebView.swift in Sources */,
 				F9AF3C542B416E5D001779E3 /* ScheduleView.swift in Sources */,
 				F9BB5B6A2B42D320002EDB68 /* SearchViewModel.swift in Sources */,
+				F9E4E3762B75F58600E276CC /* CustomTextField.swift in Sources */,
 				F96760642B3AE1CB00C09F29 /* ContentView.swift in Sources */,
 				F9AF3C5A2B416EF7001779E3 /* SettingView.swift in Sources */,
 				F9682B5A2B6B328A004A2EFE /* ScheduleRepository.swift in Sources */,

--- a/DMU-iOS/DMU-iOS/Features/Search/ViewModels/SearchViewModel.swift
+++ b/DMU-iOS/DMU-iOS/Features/Search/ViewModels/SearchViewModel.swift
@@ -9,18 +9,21 @@ import Foundation
 
 class SearchViewModel: ObservableObject {
     
-    @Published var searchText = ""
+    @Published var searchText = "" {
+        didSet {
+            if searchText.isEmpty {
+                searchedText = ""
+            }
+        }
+    }
+    
+    @Published var searchedText = ""
     @Published var isEditing = false
     @Published var isNavigating: Bool = false
-    @Published var recentSearches: [String] = []
     @Published var universityNotices: [UniversityNotice] = sampleUniversityNotices
     @Published var departmentNotices: [DepartmentNotice] = sampleDepartmentNotices
     
-    func clearText() {
-        self.searchText = ""
-        
-        onSearchTextChange()
-    }
+    
     
     // MARK: 검색 화면 날짜 데이터 포맷
     func formatDate(_ date: Date) -> String {
@@ -31,54 +34,44 @@ class SearchViewModel: ObservableObject {
         return formatter.string(from: date)
     }
     
-    // MARK: ViewModel이 초기화 될 때, UserDefaults에서 최근 검색어 불러오기
-    init() {
-        loadRecentSearches()
+    // MARK: 검색 필드 편집을 시작하는 메서드
+    func startSearchEditing() {
+        isEditing = true
     }
     
-    // MARK: UserDefaults에서 최근 검색어 데이터 불러오는 메서드
-    func loadRecentSearches() {
-        if let searches = UserDefaults.standard.array(forKey: "recentSearches") as? [String] {
-            self.recentSearches = searches
-        }
+    // MARK: 검색 필드 편집을 종료하는 메서드
+    func endSearchEditing() {
+        isEditing = false
     }
     
-    // MARK: UserDefaults에 최근 검색어 데이터를 저장하는 메서드
-    private func saveRecentSearches() {
-        UserDefaults.standard.set(self.recentSearches, forKey: "recentSearches")
+    // MARK: 검색어 삭제 메서드
+    func clearText() {
+        self.searchText = ""
     }
     
-    // MARK: 최근 검색어를 추가하는 메서드
-    func addRecentSearch(_ search: String) {
-        if !search.isEmpty && !self.recentSearches.contains(search) {
-            self.recentSearches.append(search)
-            // 배열 크기 제한 또는 오래된 검색어 제거 로직 추가 가능
-            saveRecentSearches()
-        }
-    }
-    
-    // MARK: 최근 검색어를 삭제하는 메서드
-    func removeRecentSearch(_ search: String) {
-        self.recentSearches.removeAll { $0 == search }
-        
-        saveRecentSearches()
-    }
-    
-    // MARK: 검색어가 변경될 때 호출되는 메서드
-    func onSearchTextChange() {
-        if searchText.isEmpty {
-            loadRecentSearches()
-        } else {
-            recentSearches = []
-        }
-    }
-    
-    // MARK: 검색을 수행할 때 호출되는 메서드
+    // MARK: 검색 기능 수행 시 호출하는 메서드
     func performSearch() {
         if !searchText.isEmpty {
-            addRecentSearch(searchText)
+            self.searchedText = self.searchText
+        }
+    }
+    
+    var shouldShowResults: Bool {
+        return !searchedText.isEmpty
+    }
+    
+    // MARK: 검색 필터링
+    var filteredUniversityNotices: [UniversityNotice] {
+        return universityNotices.filter { notice in
+            searchedText.isEmpty ||
+            notice.notice.noticeTitle.lowercased().contains(searchedText.lowercased())
+        }
+    }
+    
+    var filteredDepartmentNotices: [DepartmentNotice] {
+        return departmentNotices.filter { notice in
+            searchedText.isEmpty ||
+            notice.notice.noticeTitle.lowercased().contains(searchedText.lowercased())
         }
     }
 }
-
-

--- a/DMU-iOS/DMU-iOS/Features/Search/ViewModels/SearchViewModel.swift
+++ b/DMU-iOS/DMU-iOS/Features/Search/ViewModels/SearchViewModel.swift
@@ -79,20 +79,6 @@ class SearchViewModel: ObservableObject {
             addRecentSearch(searchText)
         }
     }
-    
-    // MARK: 모든 결과 보기 버튼을 눌렀을 때 검색 수행
-    func showAllResults() {
-        performSearch()
-    }
-    
-    // MARK: 검색 뷰로 돌아왔을 때 호출될 초기화 메서드
-    func resetSearchState() {
-        searchText = ""
-        isEditing = false
-        isNavigating = false
-        
-        loadRecentSearches()
-    }
 }
 
 

--- a/DMU-iOS/DMU-iOS/Features/Search/ViewModels/SearchViewModel.swift
+++ b/DMU-iOS/DMU-iOS/Features/Search/ViewModels/SearchViewModel.swift
@@ -16,10 +16,8 @@ class SearchViewModel: ObservableObject {
             }
         }
     }
-    
     @Published var searchedText = ""
     @Published var isEditing = false
-    @Published var isNavigating: Bool = false
     @Published var universityNotices: [UniversityNotice] = sampleUniversityNotices
     @Published var departmentNotices: [DepartmentNotice] = sampleDepartmentNotices
     
@@ -52,7 +50,13 @@ class SearchViewModel: ObservableObject {
     // MARK: 검색 기능 수행 시 호출하는 메서드
     func performSearch() {
         if !searchText.isEmpty {
-            self.searchedText = self.searchText
+            DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+                guard let self = self else { return }
+                
+                DispatchQueue.main.async {
+                    self.searchedText = self.searchText
+                }
+            }
         }
     }
     

--- a/DMU-iOS/DMU-iOS/Features/Search/Views/SearchView.swift
+++ b/DMU-iOS/DMU-iOS/Features/Search/Views/SearchView.swift
@@ -18,6 +18,9 @@ struct SearchView: View {
                 
                 SearchResults(viewModel: viewModel)
             }
+            .onTapGesture {
+                hideKeyboard()
+            }
         }
     }
 }
@@ -29,13 +32,20 @@ struct SearchBarView: View {
     
     var body: some View {
         HStack {
-            TextField("검색어를 입력하세요.", text: $viewModel.searchText, onCommit: {
-                viewModel.performSearch()
-                withAnimation {
-                    viewModel.endSearchEditing()
-                    hideKeyboard()
-                }
-            })
+            CustomTextField(
+                text: $viewModel.searchText,
+                isFirstResponder: viewModel.isEditing,
+                placeholder: "검색어를 2글자 이상 입력하세요.",
+                onCommit: {
+                    viewModel.performSearch()
+                    withAnimation {
+                        viewModel.endSearchEditing()
+                        hideKeyboard()
+                    }
+                }, 
+                textColor: UIColor.blue300
+            )
+            .frame(height: 24)
             .padding(12)
             .padding(.horizontal, 28)
             .font(.Medium16)
@@ -86,10 +96,10 @@ struct SearchCancelButton: View {
     var body: some View {
         Button(action: {
             viewModel.clearText()
-            hideKeyboard()
             withAnimation {
                 viewModel.isEditing = false
             }
+            hideKeyboard()
         }) {
             Text("취소")
                 .padding(.trailing, 20)

--- a/DMU-iOS/DMU-iOS/Features/Search/Views/SearchView.swift
+++ b/DMU-iOS/DMU-iOS/Features/Search/Views/SearchView.swift
@@ -155,32 +155,16 @@ struct SearchResultsListView: View {
 
             LazyVStack(alignment: .leading) {
                 ForEach(universityNotices, id: \.id) { notice in
-                    SearchResultSingleView(universityNotice: notice, viewModel: viewModel)
+                    NavigationLink(destination: NoticeWebViewDetail(urlString: notice.notice.noticeURL)){
+                        SearchResultSingleView(universityNotice: notice, viewModel: viewModel)
+                    }
                 }
 
                 ForEach(departmentNotices, id: \.id) { notice in
-                    SearchResultSingleView(departmentNotice: notice, viewModel: viewModel)
+                    NavigationLink(destination: NoticeWebViewDetail(urlString: notice.notice.noticeURL)){
+                        SearchResultSingleView(departmentNotice: notice, viewModel: viewModel)
+                    }
                 }
-            }
-
-            
-            if sampleData.filter({ item in
-                item.noticeTitle.lowercased().contains(viewModel.searchText.lowercased())
-            }).count > 3 {
-                Button(action: {
-                    viewModel.performSearch()
-                    self.navigateToSearchDetail = true
-                    
-                }) {
-                    Text("결과 모두 보기")
-                        .font(.Bold16)
-                        .foregroundColor(Color.Blue400)
-                        .frame(maxWidth: .infinity)
-                        .padding()
-                }
-                .background(.clear)
-                .cornerRadius(8)
-                .padding(.horizontal, 20)
             }
         }
     }

--- a/DMU-iOS/DMU-iOS/Resources/Assets.xcassets/Color Styles/Red200.colorset/Contents.json
+++ b/DMU-iOS/DMU-iOS/Resources/Assets.xcassets/Color Styles/Red200.colorset/Contents.json
@@ -5,8 +5,8 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.945",
-          "green" : "0.945",
+          "blue" : "0.867",
+          "green" : "0.867",
           "red" : "1.000"
         }
       },

--- a/DMU-iOS/DMU-iOS/Resources/Assets.xcassets/Color Styles/Red300.colorset/Contents.json
+++ b/DMU-iOS/DMU-iOS/Resources/Assets.xcassets/Color Styles/Red300.colorset/Contents.json
@@ -5,8 +5,8 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.945",
-          "green" : "0.945",
+          "blue" : "0.682",
+          "green" : "0.682",
           "red" : "1.000"
         }
       },

--- a/DMU-iOS/DMU-iOS/Resources/Assets.xcassets/Color Styles/Red400.colorset/Contents.json
+++ b/DMU-iOS/DMU-iOS/Resources/Assets.xcassets/Color Styles/Red400.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.945",
-          "green" : "0.945",
-          "red" : "1.000"
+          "blue" : "0.369",
+          "green" : "0.369",
+          "red" : "0.922"
         }
       },
       "idiom" : "universal"
@@ -34,5 +34,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "localizable" : true
   }
 }

--- a/DMU-iOS/DMU-iOS/Resources/Assets.xcassets/Color Styles/Red500.colorset/Contents.json
+++ b/DMU-iOS/DMU-iOS/Resources/Assets.xcassets/Color Styles/Red500.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.945",
-          "green" : "0.945",
-          "red" : "1.000"
+          "blue" : "0.153",
+          "green" : "0.153",
+          "red" : "0.851"
         }
       },
       "idiom" : "universal"

--- a/DMU-iOS/DMU-iOS/Resources/colors/Color.swift
+++ b/DMU-iOS/DMU-iOS/Resources/colors/Color.swift
@@ -22,4 +22,8 @@ extension Color {
     static let Blue400 = Color("Blue400")
     
     static let Red100 = Color("Red100")
+    static let Red200 = Color("Red200")
+    static let Red300 = Color("Red300")
+    static let Red400 = Color("Red400")
+    static let Red500 = Color("Red500")
 }

--- a/DMU-iOS/DMU-iOS/Shared/Views/CustomTextField.swift
+++ b/DMU-iOS/DMU-iOS/Shared/Views/CustomTextField.swift
@@ -1,0 +1,59 @@
+//
+//  CustomTextField.swift
+//  DMU-iOS
+//
+//  Created by 이예빈 on 2/9/24.
+//
+
+import SwiftUI
+
+struct CustomTextField: UIViewRepresentable {
+    @Binding var text: String
+    var isFirstResponder: Bool = false
+    var placeholder: String = ""
+    var onCommit: (() -> Void)? = nil
+    var textColor: UIColor = .black
+
+    func makeUIView(context: Context) -> UITextField {
+        let textField = UITextField()
+        textField.returnKeyType = .done
+        textField.placeholder = placeholder
+        textField.textColor = textColor
+        textField.delegate = context.coordinator
+        return textField
+    }
+
+    func updateUIView(_ uiView: UITextField, context: Context) {
+        uiView.text = text
+        if isFirstResponder {
+            uiView.becomeFirstResponder()
+        }
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+
+    class Coordinator: NSObject, UITextFieldDelegate {
+        var parent: CustomTextField
+
+        init(_ textField: CustomTextField) {
+            self.parent = textField
+        }
+
+        func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+            if let currentText = textField.text,
+               let textRange = Range(range, in: currentText) {
+                let updatedText = currentText.replacingCharacters(in: textRange, with: string)
+                parent.text = updatedText
+            }
+            return true
+        }
+        
+        func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+            textField.resignFirstResponder()
+            parent.onCommit?()
+            return true
+        }
+    }
+}


### PR DESCRIPTION
## 📍 _Issue_

- #55 

## 🗝️ _Key Changes_

검색 및 공지 디테일 화면 및 연결 제거 후 웹뷰로 연결했습니다.
현재 임시 데이터 Notice로 연결한 상태이며 추후 api 연결 시 데이터 모델 생성 예정입니다.

시뮬레이터에서 키보드가 보이지 않는 에러는 Simulator 활성화했을 때 `shift + command + K`를 통해 맥북 키보드 대신 Simulator 내장 키보드를 사용할 수 있게 설정했습니다.
또한, 텍스트 필드에서 검색어 입력 시 키보드 Return에 완료 버튼을 활성화할 수 있도록 UIkit의 TextField를 커스텀하여 사용했습니다.

현재 iPhone 15의 경우 Simulator에서 렉이 자주 발생하여 iPhone 14를 통해 테스트를 진행합니다.

추가적으로 이슈 #61 에서 진행된 코드리뷰에 대한 반영은 해당 PR 머지 후 진행하겠습니다.

## 📱 _Simulation_

https://github.com/TeamDMU/DMU-iOS/assets/84004751/340d4031-df44-4866-b98a-4632968bb844

## 📁 _Reference_

-

## 👥 _To Reviewers_

-
