### PR TITLE
[UI] 키워드 설정 화면

### DIFF
--- a/DMU-iOS/DMU-iOS/Shared/Views/CustomKeyword.swift
+++ b/DMU-iOS/DMU-iOS/Shared/Views/CustomKeyword.swift
@@ -29,7 +29,7 @@ struct CustomKeyword: View {
                             .font(.Medium20)
                             .foregroundColor(Color.Gray600)
                         
-                        LazyVGrid(columns: [GridItem(.adaptive(minimum: 88), spacing: 0, alignment: .leading)], spacing: 16) {
+                        LazyVGrid(columns: [GridItem(.adaptive(minimum: 90), spacing: 0, alignment: .leading)], spacing: 16) {
                             ForEach(contents[index], id: \.self) { content in
                                 SelectableButton(content: content, isSelected: Binding(get: {
                                     self.selectedKeywords[title, default: []].contains(content)
@@ -70,6 +70,7 @@ struct SelectableButton: View {
             Text(content)
                 .font(.SemiBold16)
                 .foregroundColor(isSelected ? Color.white : Color.Gray400)
+                .frame(width: 70, alignment: .center)
                 .padding(EdgeInsets(top: 5, leading: 16, bottom: 5, trailing: 16))
                 .background(isSelected ? Color.Blue300 : Color.white)
                 .cornerRadius(5)
@@ -79,5 +80,16 @@ struct SelectableButton: View {
                 )
         }
         .buttonStyle(PlainButtonStyle())
+    }
+}
+
+struct CustomKeyword_Previews: PreviewProvider {
+    @State static var selectedKeywords: [String: [String]] = [
+        "수업" : ["시험"],
+        "학적" : ["복학"]
+    ]
+
+    static var previews: some View {
+        CustomKeyword(selectedKeywords: $selectedKeywords)
     }
 }


### PR DESCRIPTION
## 📍 _Issue_

- #67

## 🗝️ _Key Changes_

딱히 바뀐건 없고 키워드 설정 선택하는 버튼의 넓이를 고정하여 여백을 일정하게 설정했습니다.
(디자인이 바뀐 걸 수정했음)

## 📱 _Simulation_

화면 캡쳐로 대체합니다.
<div style="display: flex;">
  <img width="335" alt="스크린샷 2024-02-18 오후 6 50 07" src="https://github.com/TeamDMU/DMU-iOS/assets/84004751/b7a6dc4b-6f39-4dec-b5ee-a5a4e54298ee">
  <img width="335" alt="스크린샷 2024-02-18 오후 6 49 54" src="https://github.com/TeamDMU/DMU-iOS/assets/84004751/16e0fc89-e025-448b-b0ab-3432f606204e">
</div>

## 📁 _Reference_

-

## 👥 _To Reviewers_

-