### PR TITLE
[FEAT] 화면 내 리스트뷰 새로고침, api 호출 관련

### DIFF
--- a/DMU-iOS/DMU-iOS/Features/Home/ViewModels/NoticeViewModel.swift
+++ b/DMU-iOS/DMU-iOS/Features/Home/ViewModels/NoticeViewModel.swift
@@ -19,18 +19,9 @@ class NoticeViewModel: ObservableObject {
     @Published var departmentNotices: [DepartmentNotice] = []
     @Published var isShowingWebView = false
     
-    
-    // MARK: -학과별 필터링을 위한 UserSetting 초기화
-    private var userSettings: UserSettings
-    
-    init(userSettings: UserSettings) {
-        self.userSettings = userSettings
-        resetAndLoadFirstPageOfUniversityNotices()
-        resetAndLoadFirstPageOfDepartmentNotices(department: userSettings.selectedDepartment)
-    }
-    
     // MARK: - 대학공지 데이터 통신
     @Published var isUniversityNoticeLoading = false
+    
     private var universityNoticeCurrentPage = 1
     private let universityNoticeItemsPerPage = 10
     private let universityNoticeService = UniversityNoticeService()
@@ -103,10 +94,10 @@ class NoticeViewModel: ObservableObject {
         }
     }
     
-    func loadNextPageIfNotLoading() {
+    func loadNextPageIfNotLoading(department: String) {
         if !isDepartmentNoticeLoading {
             departmentNoticeCurrentPage += 1
-            loadNextPageOfDepartmentNotices(department: userSettings.selectedDepartment)
+            loadNextPageOfDepartmentNotices(department: department)
         }
     }
 }

--- a/DMU-iOS/DMU-iOS/Features/Meal/ViewModels/MealViewModel.swift
+++ b/DMU-iOS/DMU-iOS/Features/Meal/ViewModels/MealViewModel.swift
@@ -10,6 +10,7 @@ import Foundation
 class MealViewModel: ObservableObject {
     
     @Published var weeklyMenu: [Menu] = []
+    @Published var isMenuLoading = false
     
     private let menuService = MenuService()
     
@@ -25,13 +26,10 @@ class MealViewModel: ObservableObject {
         return formatter
     }()
     
-    // MARK: 금주의 식단 데이터 초기화
-    init() {
-        loadMenuData()
-    }
-    
     // MARK: 금주의 식단 데이터 통신
     func loadMenuData() {
+        self.isMenuLoading = true
+        
         menuService.getMenus { [weak self] result in
             switch result {
             case .success(let menus):
@@ -41,6 +39,7 @@ class MealViewModel: ObservableObject {
             case .failure(let error):
                 print("Failed to get menus: \(error)")
             }
+            self?.isMenuLoading = false
         }
     }
     

--- a/DMU-iOS/DMU-iOS/Features/Meal/Views/MealView.swift
+++ b/DMU-iOS/DMU-iOS/Features/Meal/Views/MealView.swift
@@ -14,17 +14,26 @@ struct MealView: View {
     @State private var selectedDate = Date()
     
     var body: some View {
-        VStack(alignment: .center) {
-            MealTitleView()
-            
-            WeeklyCalendarView(selectedDate: $selectedDate, startDate: viewModel.startOfWeek(date: Date()))
-            
-            RestaurantInfomationView()
-            
-            WeeklyMenuView(viewModel: viewModel, selectedDate: selectedDate)
-            
-            Spacer()
+        ZStack {
+            VStack(alignment: .center) {
+                MealTitleView()
+                
+                WeeklyCalendarView(selectedDate: $selectedDate, startDate: viewModel.startOfWeek(date: Date()))
+                
+                RestaurantInfomationView()
+                
+                WeeklyMenuView(viewModel: viewModel, selectedDate: selectedDate)
+                
+                Spacer()
+            }
+            VStack {
+                if viewModel.isMenuLoading {
+                    LoadingView(lottieFileName: "DMforU_Loading_GIF")
+                        .frame(width: 100, height: 100)
+                }
+            }
         }
+        .onAppear(perform: viewModel.loadMenuData)
     }
 }
 

--- a/DMU-iOS/DMU-iOS/Features/Schedule/ViewModels/ScheduleViewModel.swift
+++ b/DMU-iOS/DMU-iOS/Features/Schedule/ViewModels/ScheduleViewModel.swift
@@ -8,9 +8,7 @@
 import Foundation
 
 class ScheduleViewModel: ObservableObject {
-    
-    static let shared = ScheduleViewModel()
-    
+        
     @Published var currentDate = Date()
     @Published var schedules: [Schedule] = []
     @Published var isScheduleLoading = false

--- a/DMU-iOS/DMU-iOS/Features/Schedule/ViewModels/ScheduleViewModel.swift
+++ b/DMU-iOS/DMU-iOS/Features/Schedule/ViewModels/ScheduleViewModel.swift
@@ -9,8 +9,11 @@ import Foundation
 
 class ScheduleViewModel: ObservableObject {
     
+    static let shared = ScheduleViewModel()
+    
     @Published var currentDate = Date()
     @Published var schedules: [Schedule] = []
+    @Published var isScheduleLoading = false
     
     private let calendar = Calendar.current
     private let scheduleService = ScheduleService()
@@ -21,15 +24,13 @@ class ScheduleViewModel: ObservableObject {
         return formatter
     }()
     
-    // MARK: 학사일정 데이터 초기화
-    init() {
-        loadScheduleData()
-    }
-    
     // MARK: 학사일정 데이터 주입
     func loadScheduleData() {
         let year = calendar.component(.year, from: currentDate)
         let month = calendar.component(.month, from: currentDate)
+        
+        self.isScheduleLoading = true
+        
         scheduleService.getSchedules(year: year, month: month) { [weak self] result in
             switch result {
             case .success(let yearSchedule):
@@ -39,6 +40,7 @@ class ScheduleViewModel: ObservableObject {
             case .failure(let error):
                 print("Failed to get schedules: \(error)")
             }
+            self?.isScheduleLoading = false
         }
     }
     

--- a/DMU-iOS/DMU-iOS/Features/Schedule/Views/ScheduleView.swift
+++ b/DMU-iOS/DMU-iOS/Features/Schedule/Views/ScheduleView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct ScheduleView: View {
     
-    @ObservedObject var viewModel = ScheduleViewModel.shared
+    @ObservedObject var viewModel: ScheduleViewModel
     
     var body: some View {
         ZStack{

--- a/DMU-iOS/DMU-iOS/Features/Schedule/Views/ScheduleView.swift
+++ b/DMU-iOS/DMU-iOS/Features/Schedule/Views/ScheduleView.swift
@@ -111,5 +111,5 @@ struct ScheduleView: View {
 }
 
 #Preview {
-    ScheduleView()
+    ScheduleView(viewModel: ScheduleViewModel())
 }

--- a/DMU-iOS/DMU-iOS/Features/Schedule/Views/ScheduleView.swift
+++ b/DMU-iOS/DMU-iOS/Features/Schedule/Views/ScheduleView.swift
@@ -9,17 +9,26 @@ import SwiftUI
 
 struct ScheduleView: View {
     
-    @ObservedObject var viewModel = ScheduleViewModel()
+    @ObservedObject var viewModel = ScheduleViewModel.shared
     
     var body: some View {
-        VStack {
-            ScheduleTitle
+        ZStack{
+            VStack {
+                ScheduleTitle
+                
+                ScheduleMonthNavigationBarView
+                
+                SchedulesListView
+            }
             
-            ScheduleMonthNavigationBarView
-            
-            SchedulesListView
+            VStack {
+                if viewModel.isScheduleLoading {
+                    LoadingView(lottieFileName: "DMforU_Loading_GIF")
+                        .frame(width: 100, height: 100)
+                }
+            }
         }
-        //.onAppear(perform: viewModel.loadScheduleData)
+        .onAppear(perform: viewModel.loadScheduleData)
     }
     
     // MARK: 학사일정 화면 타이틀 뷰
@@ -69,6 +78,9 @@ struct ScheduleView: View {
                     ScheduleSingleView(for: schedule)
                 }
             }
+        }
+        .refreshable {
+            viewModel.loadScheduleData()
         }
     }
     

--- a/DMU-iOS/DMU-iOS/Features/TabBar/Views/TabBarView.swift
+++ b/DMU-iOS/DMU-iOS/Features/TabBar/Views/TabBarView.swift
@@ -29,7 +29,7 @@ struct TabBarView: View {
             TabView(selection: $viewModel.selectedTab) {
                 
                 // MARK: 공지사항 화면
-                HomeView()
+                HomeView(viewModel: NoticeViewModel(), userSettings: UserSettings())
                     .tabItem {
                         Image(systemName: "house")
                             .resizable()
@@ -61,7 +61,7 @@ struct TabBarView: View {
                     .tag(Tab.Search)
                 
                 // MARK: 일정 화면
-                ScheduleView()
+                ScheduleView(viewModel: ScheduleViewModel())
                     .tabItem {
                         Image(systemName: "calendar")
                             .resizable()


### PR DESCRIPTION
## 📍 _Issue_

- #89 

## 🗝️ _Key Changes_

탭뷰로 화면이 생성될 때마다 지속적으로 통신 함수가 수행되는 이슈를 수정했습니다.
현재 리스트뷰 새로고침은 학사일정에 대한 부분만 추가한 상태입니다.

## 📱 _Simulation_

-

## 📁 _Reference_

-

## 👥 _To Reviewers_

-
