### PR TITLE
[FIX] 키워드 설정 화면

### DIFF
--- a/DMU-iOS/DMU-iOS.xcodeproj/project.pbxproj
+++ b/DMU-iOS/DMU-iOS.xcodeproj/project.pbxproj
@@ -66,6 +66,7 @@
 		F95DC1342B91B835001D3419 /* SearchNoticeDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = F95DC1332B91B835001D3419 /* SearchNoticeDTO.swift */; };
 		F95DC1372B91BE55001D3419 /* SearchNotice.swift in Sources */ = {isa = PBXBuildFile; fileRef = F95DC1362B91BE55001D3419 /* SearchNotice.swift */; };
 		F95DC1392B91E005001D3419 /* SearchNoticeRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = F95DC1382B91E005001D3419 /* SearchNoticeRepository.swift */; };
+		F960A04B2C40C12800CAD21D /* AppStoreCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = F960A04A2C40C12800CAD21D /* AppStoreCheck.swift */; };
 		F96760622B3AE1CB00C09F29 /* DMU_iOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = F96760612B3AE1CB00C09F29 /* DMU_iOSApp.swift */; };
 		F96760642B3AE1CB00C09F29 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F96760632B3AE1CB00C09F29 /* ContentView.swift */; };
 		F96760662B3AE1CC00C09F29 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F96760652B3AE1CC00C09F29 /* Assets.xcassets */; };
@@ -144,6 +145,7 @@
 		F95DC1332B91B835001D3419 /* SearchNoticeDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchNoticeDTO.swift; sourceTree = "<group>"; };
 		F95DC1362B91BE55001D3419 /* SearchNotice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchNotice.swift; sourceTree = "<group>"; };
 		F95DC1382B91E005001D3419 /* SearchNoticeRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchNoticeRepository.swift; sourceTree = "<group>"; };
+		F960A04A2C40C12800CAD21D /* AppStoreCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStoreCheck.swift; sourceTree = "<group>"; };
 		F967605E2B3AE1CB00C09F29 /* DMU-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "DMU-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		F96760612B3AE1CB00C09F29 /* DMU_iOSApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DMU_iOSApp.swift; sourceTree = "<group>"; };
 		F96760632B3AE1CB00C09F29 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -313,6 +315,7 @@
 			isa = PBXGroup;
 			children = (
 				F96760612B3AE1CB00C09F29 /* DMU_iOSApp.swift */,
+				F960A04A2C40C12800CAD21D /* AppStoreCheck.swift */,
 				F93F51232B47A31800654F6D /* UserSettings.swift */,
 				F96760632B3AE1CB00C09F29 /* ContentView.swift */,
 			);
@@ -931,6 +934,7 @@
 				F9BCAA892B73D38100E717BF /* NoticeWebView.swift in Sources */,
 				F9AF3C542B416E5D001779E3 /* ScheduleView.swift in Sources */,
 				F93D03122BB251BF00F6AFDE /* NotificationViewModel.swift in Sources */,
+				F960A04B2C40C12800CAD21D /* AppStoreCheck.swift in Sources */,
 				F93D03042BB24D8300F6AFDE /* NotificationService.swift in Sources */,
 				F9BB5B6A2B42D320002EDB68 /* SearchViewModel.swift in Sources */,
 				F92116172B90621000A5507A /* DepartmentNoticeDTO.swift in Sources */,

--- a/DMU-iOS/DMU-iOS.xcodeproj/project.pbxproj
+++ b/DMU-iOS/DMU-iOS.xcodeproj/project.pbxproj
@@ -1122,7 +1122,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.4;
+				MARKETING_VERSION = 1.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.leeyebeen.DMU-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -1162,7 +1162,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.4;
+				MARKETING_VERSION = 1.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.leeyebeen.DMU-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/DMU-iOS/DMU-iOS/App/AppStoreCheck.swift
+++ b/DMU-iOS/DMU-iOS/App/AppStoreCheck.swift
@@ -1,0 +1,48 @@
+//
+//  AppStoreCheck.swift
+//  DMU-iOS
+//
+//  Created by 이예빈 on 7/12/24.
+//
+
+import UIKit
+
+class AppStoreCheck {
+    
+    // 현재 버전 : 타겟 -> 일반 -> Version
+    static let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
+    
+    // 개발자가 내부적으로 확인하기 위한 용도 : 타겟 -> 일반 -> Build
+    static let buildNumber = Bundle.main.infoDictionary?["CFBundleVersion"] as? String
+    static let appStoreOpenUrlString = "itms-apps://itunes.apple.com/app/apple-store/6480396503"
+    
+    // 앱 스토어 최신 정보 확인
+    func latestVersion(completion: @escaping (String?) -> Void) {
+        let appleID = "6480396503"
+        guard let url = URL(string: "https://itunes.apple.com/lookup?id=\(appleID)&country=kr") else {
+            completion(nil)
+            return
+        }
+        
+        let task = URLSession.shared.dataTask(with: url) { data, response, error in
+            guard let data = data,
+                  let json = try? JSONSerialization.jsonObject(with: data, options: .allowFragments) as? [String: Any],
+                  let results = json["results"] as? [[String: Any]],
+                  let appStoreVersion = results.first?["version"] as? String else {
+                completion(nil)
+                return
+            }
+            completion(appStoreVersion)
+        }
+        task.resume()
+    }
+    
+    // 앱 스토어로 이동 -> urlStr 에 appStoreOpenUrlString 넣으면 이동
+    func openAppStore() {
+        guard let url = URL(string: AppStoreCheck.appStoreOpenUrlString) else { return }
+        if UIApplication.shared.canOpenURL(url) {
+            UIApplication.shared.open(url, options: [:], completionHandler: nil)
+        }
+    }
+}
+

--- a/DMU-iOS/DMU-iOS/Features/Notification/Views/NotificationKeywordEditView.swift
+++ b/DMU-iOS/DMU-iOS/Features/Notification/Views/NotificationKeywordEditView.swift
@@ -48,7 +48,7 @@ struct NotificationKeywordEditView: View {
                     viewModel.postUpdateKeyword()
                     isNavigatingToKeywordEditView = false
                 },
-                isEnabled: true
+                isEnabled: !tempSettingKeywords.isEmpty
             )
             
             Spacer()


### PR DESCRIPTION
## 📍 _Issue_

- #118

## 🗝️ _Key Changes_

키워드 설정 화면에서 키워드 전체 해제 시 버튼이 활성화되는 이슈를 수정했습니다. 비활성화로 바꿨습니다.
또한 현재 버전 1.1.0 심사를 위해 버전업 설정을 진행했으며, 추후 필요할 수 있는 기능인 강제 업데이트 얼럿을 추가했습니다.
앱스토어로 연결되는 것 모두 테스트 완료했습니다.

## 📱 _Simulation_

https://github.com/user-attachments/assets/16906c6f-fcd5-463b-8d13-2d1970ed1355

https://github.com/user-attachments/assets/7f70f147-5a75-4e15-8897-28474c0948c3

## 📁 _Reference_

https://velog.io/@chaentopia/iOS-Swift-%EA%B0%95%EC%A0%9C-%EC%97%85%EB%8D%B0%EC%9D%B4%ED%8A%B8-Alert-%EC%84%A4%EC%A0%95

## 👥 _To Reviewers_

