### PR TITLE
[FIX] 식단표 화면

### DIFF
--- a/DMU-iOS/DMU-iOS.xcodeproj/project.pbxproj
+++ b/DMU-iOS/DMU-iOS.xcodeproj/project.pbxproj
@@ -1126,7 +1126,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.1;
+				MARKETING_VERSION = 1.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.leeyebeen.DMU-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -1166,7 +1166,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.1;
+				MARKETING_VERSION = 1.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.leeyebeen.DMU-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/DMU-iOS/DMU-iOS/Features/Meal/Models/DTO/Menu.swift
+++ b/DMU-iOS/DMU-iOS/Features/Meal/Models/DTO/Menu.swift
@@ -16,11 +16,25 @@ struct Menu: Identifiable {
 }
 
 // MARK: - 일품
+
+enum Weekday: String, CaseIterable {
+    case monday = "월요일"
+    case tuesday = "화요일"
+    case wednesday = "수요일"
+    case thursday = "목요일"
+    case friday = "금요일"
+}
+
 struct OneMenu: Identifiable {
     var id = UUID()
     var details: [String]
+    var availableDays: [Weekday]
 }
 
 let OneMenuList = [
-    OneMenu(details: ["라면 3,500원", "치즈라면 4,000원", "해물라면 4,500원", "돈까스 5,000원", "치즈돈까스 5,500원", "고구마치즈돈까스 6,000원", "스팸김치볶음밥 4,900원", "치킨마요덮밥 4,500원", "불닭마요덮밥 4,500원", "오므라이스 5,500원"]),
+    OneMenu(details: ["라면 3,500원", "치즈라면 4,000원", "해물라면 4,500원"], availableDays: [.monday, .tuesday, .wednesday, .thursday, .friday]),
+    OneMenu(details: ["돈까스 5,000원", "치즈돈까스 5,500원", "고구마치즈돈까스 6,000원"], availableDays: [.monday, .tuesday, .wednesday, .thursday, .friday]),
+    OneMenu(details: ["스팸김치볶음밥 4,900원"], availableDays: [.monday, .tuesday]),
+    OneMenu(details: ["치킨마요덮밥 4,500원", "불닭마요덮밥 4,500원"], availableDays: [.wednesday, .thursday]),
+    OneMenu(details: ["오므라이스 5,500원"], availableDays: [.friday]),
 ]

--- a/DMU-iOS/DMU-iOS/Features/Meal/ViewModels/MealViewModel.swift
+++ b/DMU-iOS/DMU-iOS/Features/Meal/ViewModels/MealViewModel.swift
@@ -71,4 +71,27 @@ class MealViewModel: ObservableObject {
         
         return menuForDate
     }
+    
+    // MARK: - 요일별 일품 메뉴 필터링
+        func filteredOneMenu(for date: Date) -> [OneMenu] {
+            let weekday = calendar.component(.weekday, from: date)
+            let selectedWeekday: Weekday
+
+            switch weekday {
+            case 2:
+                selectedWeekday = .monday
+            case 3:
+                selectedWeekday = .tuesday
+            case 4:
+                selectedWeekday = .wednesday
+            case 5:
+                selectedWeekday = .thursday
+            case 6:
+                selectedWeekday = .friday
+            default:
+                return [] // 월요일에서 금요일, 외의 요일은 처리하지 않음
+            }
+            
+            return weeklyOneMenu.filter { $0.availableDays.contains(selectedWeekday) }
+        }
 }

--- a/DMU-iOS/DMU-iOS/Features/Meal/Views/MealView.swift
+++ b/DMU-iOS/DMU-iOS/Features/Meal/Views/MealView.swift
@@ -198,11 +198,16 @@ struct WeeklyMenuDetailView: View {
         GeometryReader { geometry in
             ScrollView {
                 VStack {
+                    // 한식 메뉴
                     if let menu = viewModel.getMenuForDate(for: selectedDate) {
                         MenuDetailSingleView(category: "🍚 한식", details: menu.details, width: geometry.size.width)
                     }
+                    
                     Spacer(minLength: 20)
-                    let oneMenu = viewModel.weeklyOneMenu.flatMap { $0.details }
+                    
+                    // 일품 메뉴
+                    let oneMenu = viewModel.filteredOneMenu(for: selectedDate).flatMap { $0.details }
+                    
                     MenuDetailSingleView(category: "🍛 일품", details: oneMenu, width: geometry.size.width)
                 }
                 .padding(.top, 30)

--- a/DMU-iOS/DMU-iOS/Features/Meal/Views/MealView.swift
+++ b/DMU-iOS/DMU-iOS/Features/Meal/Views/MealView.swift
@@ -136,7 +136,7 @@ struct RestaurantInfomationView: View {
         HStack(alignment: .center) {
             InfomationSingleView(imageName: "map", text: "8호관 3층")
                 .padding(.trailing, 20)
-            InfomationSingleView(imageName: "clock", text: "11:00 - 14:00, 16:30 - 18:00")
+            InfomationSingleView(imageName: "clock", text: "11:00 - 14:00")
         }
         .padding(.top, 20)
     }


### PR DESCRIPTION
## 📍 _Issue_

- #120

## 🗝️ _Key Changes_

기존의 방식으로는 일품의 모든 메뉴가 나오는 화면이었으나 최근 사용자 피드백을 반영하여 요일별로 일품 메뉴를 표기하였습니다.
추석 기간에는 심사를 넣지 않고 연휴 이후 한 번 더 테스트 후 심사 넣도록 하겠습니다.

## 📱 _Simulation_

https://github.com/user-attachments/assets/7db93dc7-e9fe-419c-a7b9-e3001b9cc7bf

## 📁 _Reference_


## 👥 _To Reviewers_

